### PR TITLE
fix(deps): replace deprecated GitHub Actions

### DIFF
--- a/cache-cargo-dependencies/action.yml
+++ b/cache-cargo-dependencies/action.yml
@@ -4,7 +4,7 @@ description: A simple wrapper around actions/cache configured with common Cargo 
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3.3.2
+    - uses: actions/cache@v4
       name: Cache cargo dependencies
       with:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}

--- a/checkout-rust-project/action.yml
+++ b/checkout-rust-project/action.yml
@@ -22,10 +22,9 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - uses: tomphp/github-actions/cache-cargo-dependencies@v0.1.0
-    - uses: actions-rs/toolchain@v1.0.7
+    - uses: ./cache-cargo-dependencies
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: ${{ inputs.rust-profile }}
         toolchain: ${{ inputs.rust-toolchain }}
-        default: ${{ inputs.rust-default }}
         components: ${{ inputs.rust-components }}
+        cache: false


### PR DESCRIPTION
## Summary

- Bump `actions/cache` from `v3.3.2` to `v4` in `cache-cargo-dependencies/action.yml` — GitHub is now blocking jobs that use `actions/cache` v1/v2/v3.x
- Replace deprecated `actions-rs/toolchain@v1.0.7` (which also internally uses `actions/cache@v3.3.2`) with `actions-rust-lang/setup-rust-toolchain@v1`
- Update `checkout-rust-project/action.yml` to reference `./cache-cargo-dependencies` locally so PR branches pick up the fix immediately

This unblocks the failing `test-checkout-rust-project` jobs in PR #16 and on `main`.

## Test plan

- [ ] `test-checkout-rust-project / test-with-default-arguments` passes
- [ ] `test-checkout-rust-project / test-with-clippy-component-installed` passes
- [ ] All other test jobs continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)